### PR TITLE
use @apache.org address for chairs

### DIFF
--- a/lib/whimsy/asf/agenda/attachments.rb
+++ b/lib/whimsy/asf/agenda/attachments.rb
@@ -35,7 +35,7 @@ class ASF::Board::Agenda
       unless @quick
         begin
           committee = ASF::Committee.find(attrs['title'])
-          attrs['chair_email'] = committee.chair.mail.first
+          attrs['chair_email'] = "#{committee.chair.id}@apache.org"
           attrs['mail_list'] = committee.mail_list
           attrs.delete('mail_list') if attrs['mail_list'].include? ' '
 


### PR DESCRIPTION
Not currently used by functions other than Whimsy agenda email capability.
Helps chairs with their filtering, and avoids putting direct forwarding
address into the copied list archives.