### PR TITLE
retain other markers in proxy form

### DIFF
--- a/www/members/proxy.cgi
+++ b/www/members/proxy.cgi
@@ -161,9 +161,13 @@ _html do
 
             # update proxies file
             proxies = IO.read('proxies')
-            list += proxies.scan(/   \S.*\(\S+\)$/).
-              select {|line| nontext.include? line[/\((\S+)\)$/, 1]}
+            existing = proxies.scan(/   \S.*\(\S+\).*$/)
+            existing_ids = existing.map {|line| line[/\((\S+)\)/, 1] }
+            added = list.
+              reject {|line| existing_ids.include? line[/\((\S+)\)$/, 1]}
+            list = added + existing
             proxies[/.*-\n(.*)/m, 1] = list.flatten.sort.join("\n") + "\n"
+
             IO.write('proxies', proxies)
 
             # commit


### PR DESCRIPTION
Instead of building the list from files, then attempting to add back text,
retain the original text but add any files that were not found based on the
user ID