### PR TITLE
Fix typo in references to committee-info.txt

### DIFF
--- a/www/classic/roster/js/app._js
+++ b/www/classic/roster/js/app._js
@@ -126,13 +126,13 @@ module Angular::AsfRoster
       @status = 'not in LDAP'
       @hint = "modify_committee.pl #{@name} --add #{@person.uid}"
     elsif not (@info.memberUid.include? @person.uid or @info.memberUid.empty?)
-      @status = 'not in committee_info.txt'
+      @status = 'not in committee-info.txt'
       @hint = "modify_committee.pl #{@name} --rm #{@person.uid}"
     elsif @pmc.group and not @pmc.group.memberUid.include? @person.uid
       @status = 'not in committer list'
       @hint = "modify_unix_group.pl #{@name} --add #{@person.uid}"
     elsif (@person.cn && @info.names[@person.uid]) != @person.cn
-      @status = "name in committee_info.txt doesn't match public name"
+      @status = "name in committee-info.txt doesn't match public name"
       @hint = "listed as #{@info.names[@person.uid]}"
     elsif @person.uid == @info.chair
       @status = 'chair'

--- a/www/roster/views/committee.js.rb
+++ b/www/roster/views/committee.js.rb
@@ -232,9 +232,9 @@ class PMCMember < React
               data_target: '#confirm', data_toggle: 'modal',
               data_confirmation: "Remove #{@@person.name} from LDAP?"
 
-            _button.btn.btn_success 'Add to committee_info.txt',
+            _button.btn.btn_success 'Add to committee-info.txt',
               disabled: true,
-              data_confirmation: "Add to #{@@person.name} committee_info.txt"
+              data_confirmation: "Add to #{@@person.name} committee-info.txt"
           elsif not @@person.ldap
              # in committee-info.txt but not in ldap
             _button.btn.btn_success 'Add to LDAP',
@@ -242,10 +242,10 @@ class PMCMember < React
               data_target: '#confirm', data_toggle: 'modal',
               data_confirmation: "Add #{@@person.name} to LDAP?"
 
-            _button.btn.btn_warning 'Remove from committee_info.txt',
+            _button.btn.btn_warning 'Remove from committee-info.txt',
               disabled: true,
               data_confirmation: 
-                "Remove #{@@person.name} from committee_info.txt?"
+                "Remove #{@@person.name} from committee-info.txt?"
           else
             # in both LDAP and committee-info.txt
             _button.btn.btn_warning 'Remove from PMC',
@@ -263,7 +263,7 @@ class PMCMember < React
           end
         end
       elsif not @@person.date
-        _td.issue 'not in committee_info.txt'
+        _td.issue 'not in committee-info.txt'
       elsif not @@person.ldap
         _td.issue 'not in LDAP'
       elsif not @@committee.committers[@@person.id]

--- a/www/roster/views/pmc/pmc.js.rb
+++ b/www/roster/views/pmc/pmc.js.rb
@@ -124,10 +124,10 @@ class PMCMember < React
               data_target: '#confirm', data_toggle: 'modal',
               data_confirmation: "Remove #{@@person.name} from LDAP?"
 
-            _button.btn.btn_success 'Add to committee_info.txt',
+            _button.btn.btn_success 'Add to committee-info.txt',
               data_action: 'add info',
               data_target: '#confirm', data_toggle: 'modal',
-              data_confirmation: "Add to #{@@person.name} committee_info.txt"
+              data_confirmation: "Add to #{@@person.name} committee-info.txt"
           elsif not @@person.ldap
              # in committee-info.txt but not in ldap
             _button.btn.btn_success 'Add to LDAP',
@@ -135,11 +135,11 @@ class PMCMember < React
               data_target: '#confirm', data_toggle: 'modal',
               data_confirmation: "Add #{@@person.name} to LDAP?"
 
-            _button.btn.btn_warning 'Remove from committee_info.txt',
+            _button.btn.btn_warning 'Remove from committee-info.txt',
               data_action: 'remove info',
               data_target: '#confirm', data_toggle: 'modal',
               data_confirmation: 
-                "Remove #{@@person.name} from committee_info.txt?"
+                "Remove #{@@person.name} from committee-info.txt?"
           else
             # in both LDAP and committee-info.txt
             _button.btn.btn_warning 'Remove from PMC',
@@ -157,7 +157,7 @@ class PMCMember < React
           end
         end
       elsif not @@person.date
-        _td.issue 'not in committee_info.txt'
+        _td.issue 'not in committee-info.txt'
       elsif not @@person.ldap
         _td.issue 'not in LDAP'
       elsif not @@committee.committers[@@person.id]


### PR DESCRIPTION
The actual file handling committee info in svn is:
https://svn.apache.org/repos/private/committers/board/committee-info.txt