### PR TITLE
add support for inline private sections (commented)

### DIFF
--- a/www/board/agenda/models/minutes.rb
+++ b/www/board/agenda/models/minutes.rb
@@ -163,7 +163,13 @@ class Minutes
     minutes.sub! 'Meeting Agenda', 'Meeting Minutes'
     minutes.sub! /^End of agenda/, 'End of minutes'
 
+    # remove block of lines (and preceding whitespace including blank lines)
+    # where the first line starts with <private> and the last line ends with
+    # </private>.
     minutes.gsub! /^\s*<private>.*?<\/private>\s*?\n/mi, ''
+
+    # remove inline <private>...</private> sections (and preceding spaces
+    # and tabs) where the <private> and </private> are on the same line.
     minutes.gsub! /[ \t]*<private>.*?<\/private>/i, ''
 
     minutes.gsub! /\n( *)\[ comments:.*?\n\1 ? ?\]/m, ''

--- a/www/board/agenda/models/minutes.rb
+++ b/www/board/agenda/models/minutes.rb
@@ -164,6 +164,8 @@ class Minutes
     minutes.sub! /^End of agenda/, 'End of minutes'
 
     minutes.gsub! /^\s*<private>.*?<\/private>\s*?\n/mi, ''
+    minutes.gsub! /[ \t]*<private>.*?<\/private>/i, ''
+
     minutes.gsub! /\n( *)\[ comments:.*?\n\1 ? ?\]/m, ''
 
     minutes

--- a/www/board/agenda/views/pages/report.js.rb
+++ b/www/board/agenda/views/pages/report.js.rb
@@ -230,14 +230,20 @@ class Report < React
     return text
   end
 
-  # private sections
+  # highlight private sections - these sections appear in the agenda but
+  # will be removed when the minutes are produced (see models/minutes.rb)
   def privates(text)
+    # inline <private>...</private> sections (and preceding spaces and tabs)
+    # where the <private> and </private> are on the same line.
     private_inline = /([ \t]*&lt;private&gt;.*?&lt;\/private&gt;)/
 
+    # block of lines (and preceding whitespace) where the first line starts
+    # with <private> and the last line ends </private>.
     private_lines =
       Regexp.new('^([ \t]*&lt;private&gt;(?:\n|.)*?&lt;/private&gt;)(\s*)$',
       'mig')
 
+    # return the text with private sections marked with class private
     return text.
       gsub(private_inline, '<span class="private">$1</span>').
       gsub(private_lines, '<div class="private">$1</div>')

--- a/www/board/agenda/views/pages/report.js.rb
+++ b/www/board/agenda/views/pages/report.js.rb
@@ -232,11 +232,15 @@ class Report < React
 
   # private sections
   def privates(text)
-    private_sections =
+    private_inline = /([ \t]*&lt;private&gt;.*?&lt;\/private&gt;)/
+
+    private_lines =
       Regexp.new('^([ \t]*&lt;private&gt;(?:\n|.)*?&lt;/private&gt;)(\s*)$',
       'mig')
 
-    return text.gsub(private_sections, '<div class="private">$1</div>')
+    return text.
+      gsub(private_inline, '<span class="private">$1</span>').
+      gsub(private_lines, '<div class="private">$1</div>')
   end
   
   # expand president's attachments


### PR DESCRIPTION
Two forms will be supported:

1) entirely contained on one line, optionally with text before and after.

2) where <private> is the first non-blank on a line, and </private> is the
last non-blank on a line.  Note: text may follow the open tag and precede
the close tag.

It turns out the hardest part of this is determining what white space
needs to be removed in conjunction with the private markers.

clr: I'd like to see a bit more commentary (especially with regular expressions).
For example,
// remove entire lines starting with <private>... and ending with ...</private>
// remove private comments from inside a line containing ...<private>...</private>...