### PR TITLE
Show proposed new way to provide related links/helpblock in any script

### DIFF
--- a/lib/whimsy/asf/themes.rb
+++ b/lib/whimsy/asf/themes.rb
@@ -112,8 +112,7 @@ class Wunderbar::HtmlMarkup
   end
   
   # Emit a bootstrap navbar with required ASF links
-  # TODO Add breadcrumbs? Do we really need them?
-  def _whimsy_nav **args
+  def _whimsy_nav
     _nav.navbar.navbar_default do
       _div.container_fluid do
         _div.navbar_header do
@@ -188,26 +187,25 @@ class Wunderbar::HtmlMarkup
     end
   end
 
-  def _whimsy_body2 **args
-    _whimsy_nav args
+  def _whimsy_body2 title, related, helpblock
+    _whimsy_nav
     _div.content.container_fluid do
       _div.row do
         _div.col_sm_12 do
-          _h1 args[:title]
+          _h1 title
         end
       end
       _div.row do
         _div.col_md_8 do
           _whimsy_panel "About This Script" do
-            _p "Lambda intro would go here. Ipsum lorem to the lorax tree. Lambda intro would go here. Ipsum lorem to the lorax tree. "
-            _p "Hello, World! Lambda intro would go here. Ipsum lorem to the lorax tree. Lambda intro would go here. Ipsum lorem to the lorax tree. "
+            helpblock.call
           end
         end
         _div.col_md_4 do
           _whimsy_panel "More Whimsy", style: "panel-info" do
             _ul do
-              if args.key?(:related)
-                args[:related].each do |url, desc|
+              if related
+                related.each do |url, desc|
                   _li do
                     _a desc, href: url
                   end

--- a/www/committers/tools.cgi
+++ b/www/committers/tools.cgi
@@ -10,11 +10,23 @@ require '../../tools/wwwdocs.rb'
 
 _html do
   _body? do
-    _whimsy_body2 title: PAGETITLE, related: {
-      "https://projects.apache.org/" => "Learn About Apache Projects",
-      "https://community.apache.org/" => "Get Community Help",
-      "https://github.com/apache/whimsy/" => "Read The Whimsy Code"
-    } do
+    _whimsy_body2(
+      PAGETITLE, {
+        "https://projects.apache.org/" => "Apache Project Listing",
+        "https://reference.apache.org/" => "Infra Reference Pages",
+        "https://github.com/apache/whimsy/blob/master/www/committers/tools.cgi" => "See This Code"
+      },
+      -> {
+        _ 'This page shows a '
+        _em 'partial'
+        _ ' listing of the useful data and tools that Whimsy provides to Apache committers.'
+        _br
+        _ 'It is generated automatically from tools that opt-in. Future improvements 
+        include automatically noting which tools require which auth (public|committer|member|officer).'
+        _br
+        _ 'If you find this useful, please let us know at dev@whimsical!.'
+      }
+    ) do
       scan = scandir("../#{SCANDIR}") # TODO Should be a static generated file
       scan.reject{ |k, v| v[1] =~ /\A#{ISERR}/ }
         .group_by{ |k, v| v[1][0] }

--- a/www/test/test.cgi
+++ b/www/test/test.cgi
@@ -9,11 +9,19 @@ require 'wunderbar/bootstrap'
 
 _html do
   _body? do
-    _whimsy_body2 title: "Sample New Whimsy Style", related: {
-      "https://projects.apache.org/" => "Learn About Apache Projects",
-      "https://community.apache.org/" => "Get Community Help",
-      "https://github.com/apache/whimsy/" => "Read The Whimsy Code"
-    } do
+    _whimsy_body2(
+      "Sample Whimsy Theme", {
+        "https://projects.apache.org/" => "Whimsy Tool Listing",
+        "https://community.apache.org/" => "Get Community Help",
+        "https://github.com/apache/whimsy/" => "Read The Whimsy Code"
+      },
+      -> {
+        _p "This www/test/test.cgi script shows a proposed new way to write whimsy tools."
+        _p "Using lib/whimsy/theme and _whimsy_body2 means users have a consistent UI for different tools, 
+        and means that simple descriptions or help documentation are included at the start of each tool."
+        _p "Similarly, having a listing of related tools in the right hand panel helps end users find other interesting tools here."
+      }
+    ) do
       _whimsy_panel "Your Data Here" do
         _p "This is where your code would output data or a form or whatever!"
         _p "All headers/footers and nicely wrapping a row is handled by themes.rb"


### PR DESCRIPTION
Comments/suggestions for how to better show a consistent layout for users, including both a "what is this script" block as well as a short listing of related tools?