### PR TITLE
Minor changes to the podling pages:

### DIFF
--- a/www/roster/models/ppmc.rb
+++ b/www/roster/models/ppmc.rb
@@ -52,6 +52,7 @@ class PPMC
       display_name: ppmc.display_name,
       description: ppmc.description,
       schedule: ppmc.reporting,
+      monthly: ppmc.monthly,
       established: ppmc.startdate.to_s,
       mentors: ppmc.mentors,
       owners: ppmc.owners.map {|person| person.id},

--- a/www/roster/views/ppmc/main.js.rb
+++ b/www/roster/views/ppmc/main.js.rb
@@ -81,9 +81,9 @@ class PPMC < React
     _h2.reporting! 'Reporting Schedule'
     _ul do
       _li @ppmc.schedule.join(', ')
-
+      _li "Monthly: #{@ppmc.monthly.join (', ')}" if @ppmc.monthly and !@ppmc.monthly.empty?
       _li do
-        _a 'Prior reports', href: 'https://whimsy.apache.org/board/minutes/' +
+        _a 'Prior Board Reports', href: 'https://whimsy.apache.org/board/minutes/' +
           @ppmc.display_name.gsub(/\s+/, '_')
       end
     end


### PR DESCRIPTION
- Separate out the monthly and normal reporting schedules
- Change text for podling reports to indicate Board Reports
- Don't reorder reporting schedule