### PR TITLE
Allow fallback parsing of pre-2007 agendas

### DIFF
--- a/lib/whimsy/asf/agenda.rb
+++ b/lib/whimsy/asf/agenda.rb
@@ -29,6 +29,9 @@ class ASF::Board::Agenda
     '9.' => 'Action Items'
   }
 
+  # Regex for start of officer reports (accounts for style differences in early agendas)
+  OFFICER_SEPARATOR = /^\s*4. (Executive )?Officer Reports/
+
   @@parsers = []
   # convenience method.  If passed a file, will create an instance of this
   # class and call the parse method on that object.  If passed a block, will

--- a/lib/whimsy/asf/agenda/exec-officer.rb
+++ b/lib/whimsy/asf/agenda/exec-officer.rb
@@ -2,8 +2,10 @@
 
 class ASF::Board::Agenda
   parse do
-    reports = @file.split(/^ 4. Executive Officer Reports/,2).last.
-      split(/^ 5. Additional Officer Reports/,2).first
+    reports = @file.split(OFFICER_SEPARATOR,2).last
+    a = reports.split(/^ 5. Additional Officer Reports/,2).first
+    b = reports.split(/^ 5. Committee Reports/,2).first   # Allow parsing of pre-2007 reports
+    (a.length > b.length) ? reports = b : reports = a
 
     pattern = /
       \s{4}(?<section>[A-Z])\.

--- a/lib/whimsy/asf/agenda/minutes.rb
+++ b/lib/whimsy/asf/agenda/minutes.rb
@@ -3,7 +3,7 @@
 class ASF::Board::Agenda
   parse do
     minutes = @file.split(/^ 3. Minutes from previous meetings/,2).last.
-      split(/^ 4. Executive Officer Reports/,2).first
+      split(OFFICER_SEPARATOR,2).first
 
     pattern = /
       \s{4}(?<section>[A-Z])\.

--- a/lib/whimsy/asf/agenda/special.rb
+++ b/lib/whimsy/asf/agenda/special.rb
@@ -2,8 +2,8 @@
 
 class ASF::Board::Agenda
   parse do
-    orders = @file.split(/^ 7. Special Orders/,2).last.
-      split(/^ 8. Discussion Items/,2).first
+    orders = @file.split(/^ \d. Special Orders/,2).last.
+      split(/^ \d. Discussion Items/,2).first
 
     pattern = /
       \n+(?<indent>\s{3,5})(?<section>[A-Z])\.

--- a/lib/whimsy/asf/agenda/summary.rb
+++ b/lib/whimsy/asf/agenda/summary.rb
@@ -138,9 +138,11 @@ class ASF::Board::Agenda
         totcommentlen += data[COMMENT_LEN] if data[COMMENT_LEN]
         totreportlen += data[REPORT_LEN] if data[REPORT_LEN]
       end
-      summary[STATS_KEY]['avgapprovals'] = (totapprovals / totreports).round(2)
-      summary[STATS_KEY]['avgcommentlen'] = (totcommentlen / totreports).round(0)
-      summary[STATS_KEY]['avgreportlen'] = (totreportlen / totreports).round(0)
+      if totreports != 0 # Avoid NaN in minutes that aren't parsed fully
+        summary[STATS_KEY]['avgapprovals'] = (totapprovals / totreports).round(2)
+        summary[STATS_KEY]['avgcommentlen'] = (totcommentlen / totreports).round(0)
+        summary[STATS_KEY]['avgreportlen'] = (totreportlen / totreports).round(0)
+      end
     rescue StandardError => e
       summary[ERRORS_KEY] ||= "ERROR(#{meeting}) process error: #{e.message} #{e.backtrace[0]}"
     end


### PR DESCRIPTION
Produces results for pre-2007 agendas, and doesn’t affect parsing of later ones. @rubys  Needs review to ensure there isn't something else that this will erroneously report incorrect data (where it used to report correct data).