### PR TITLE
switch to the pip3 version of img2pdf

### DIFF
--- a/www/secretary/workbench/img2pdf
+++ b/www/secretary/workbench/img2pdf
@@ -1,0 +1,7 @@
+#!/usr/bin/python3
+
+# Alternate executable wrapper for img2pdf, created because the packaged
+# version of img2pdf on Ubuntu 16.04 contains a back-level version
+
+import img2pdf
+img2pdf.main()

--- a/www/secretary/workbench/models/attachment.rb
+++ b/www/secretary/workbench/models/attachment.rb
@@ -61,7 +61,8 @@ class Attachment
 
     if IMAGE_TYPES.include? ext or content_type.start_with? 'image/'
       pdf = SafeTempFile.new([safe_name, '.pdf'])
-      system 'img2pdf', '--output', pdf.path, file.path
+      img2pdf = File.expand_path('../img2pdf', __dir__.untaint).untaint
+      system img2pdf, '--output', pdf.path, file.path
       file.unlink
       return pdf
     end

--- a/www/secretary/workbench/views/actions/rotate-attachment.json.rb
+++ b/www/secretary/workbench/views/actions/rotate-attachment.json.rb
@@ -32,7 +32,7 @@ rescue
   raise
 ensure
   selected.unlink if selected
-  File.unlink output if output
+  File.unlink output if output and File.exist? output
 end
 
 {attachments: message.attachments, selected: name}


### PR DESCRIPTION
To be applied after https://github.com/apache/infrastructure-puppet/pull/1227 lands