### PR TITLE
[WHIMSY-274] Use keys.openpgp.org

### DIFF
--- a/www/secretary/workbench/views/actions/check-signature.json.rb
+++ b/www/secretary/workbench/views/actions/check-signature.json.rb
@@ -6,7 +6,8 @@ ENV['GNUPGHOME'] = GNUPGHOME if GNUPGHOME
 
 #KEYSERVER = 'pgpkeys.mit.edu'
 # Perhaps also try keyserver.pgp.com
-KEYSERVERS = %w{hkps.pool.sks-keyservers.net keyserver.ubuntu.com pgpkeys.mit.edu}
+# see WHIMSY-274 for secure servers
+KEYSERVERS = %w{keys.openpgp.org}
 
 message = Mailbox.find(@message)
 


### PR DESCRIPTION
This changes the default keyserver to keys.openpgp.org which has protections against recently exploited weaknesses in the current SKS pool.