### PR TITLE
enclose in parens or ruby will evaluate to true instead of either option

### DIFF
--- a/www/board/agenda/views/actions/post.json.rb
+++ b/www/board/agenda/views/actions/post.json.rb
@@ -19,7 +19,7 @@ attach = nil
 # Determine if user is authorized
 user = ASF::Person.find(env.user)
 member_or_officer = user.asf_member? or ASF.pmc_chairs.include? user
-credentials = member_or_officer and env.password ? 
+credentials = (member_or_officer and env.password) ? 
   nil : [['--username', 'whimsysvn']]
 
 # prepend user id to message if whimsysvn role account is used


### PR DESCRIPTION
`a = b and c ? d : e` will set a == true
`a = (b and c) ? d : e` will set a == d or a == e, depending

we need the latter here