### PR TITLE
Fix for newly elected members statistics

### DIFF
--- a/www/members/inactive.cgi
+++ b/www/members/inactive.cgi
@@ -76,16 +76,23 @@ _html do
       end
       if active
         att = miss = 0
-        matrix.each do |date, status|
-          if %w(A V P).include? status
-            att += 1
-          else
-            miss += 1
+        if !matrix.nil?
+          matrix.each do |date, status|
+            if %w(A V P).include? status
+              att += 1
+            else
+              miss += 1
+            end
           end
         end
-        _p.text_success "Great! Thanks for attending Member's meetings recently! Overall attends: #{att} Non-attends: #{miss}"
-        if 0 == miss
-          _p.text_success "WOW! 100% attendance rate - thanks!"
+
+        if 0 == miss && 0 == att
+          _p.text_success "No attendance for Member's meetings found yet"
+        else
+          _p.text_success "Great! Thanks for attending Member's meetings recently! Overall attends: #{att} Non-attends: #{miss}"
+          if 0 == miss
+            _p.text_success "WOW! 100% attendance rate - thanks!"
+          end
         end
       end
 


### PR DESCRIPTION
The following page https://whimsy.apache.org/members/inactive.cgi returns an error when now statistics are available (e.g. for newly elected members).

![afbeelding](https://user-images.githubusercontent.com/10008950/73974364-82c7bd80-4924-11ea-8110-69bf8a0b509f.png)

This PR solves the nil error and returns the following in case no statistics are available:
![afbeelding](https://user-images.githubusercontent.com/10008950/73974421-9f63f580-4924-11ea-9663-d62fce99aeb9.png)

Hope the fix is in the correct place ;)
