### PR TITLE
WHIMSY-314: Replaced a.o/img/ with a.o/logos/

### DIFF
--- a/lib/whimsy/sitestandards.rb
+++ b/lib/whimsy/sitestandards.rb
@@ -115,8 +115,8 @@ module SiteStandards
       CHECK_CAPTURE => nil,
       CHECK_VALIDATE => %r{.},
       CHECK_TYPE => true,
-      CHECK_POLICY => 'https://www.apache.org/img/',
-      CHECK_DOC => 'Projects SHOULD include a 212px wide copy of their logo in https://www.apache.org/img/ to be included in ASF homepage.',
+      CHECK_POLICY => 'https://www.apache.org/logos/',
+      CHECK_DOC => 'Projects SHOULD add a copy of their logo to https://www.apache.org/logos/ to be included in ASF homepage.',
     },
   }
   

--- a/repository.yml
+++ b/repository.yml
@@ -125,7 +125,7 @@
     depth: files
 
   site-img:
-    url: asf/infrastructure/site/trunk/content/img
+    url: asf/comdev/project-logos/originals
 
   site-root:
     url: asf/infrastructure/site/trunk/content

--- a/tools/site-scan.rb
+++ b/tools/site-scan.rb
@@ -146,7 +146,7 @@ def parse(id, site, name)
   end
   # THIRD: see if an image has been uploaded
   if IMAGE_DIR
-    data[:image] = Dir[File.join(IMAGE_DIR, "#{id}.*")].
+    data[:image] = Dir[File.join(IMAGE_DIR, "#{id}*.{svg,eps,ai,pdf}")].
       map {|path| File.basename(path)}.first
   end
 

--- a/www/roster/models/committee.rb
+++ b/www/roster/models/committee.rb
@@ -20,7 +20,7 @@ class Committee
     info = JSON.parse(File.read(File.join(comdev, 'projects.json')))[id]
 
     image_dir = ASF::SVN.find('site-img')
-    image = Dir[File.join(image_dir, "#{id}.*")].map {|path| File.basename(path)}.last
+    image = Dir[File.join(image_dir, "#{id}*.{svg,eps,ai,pdf}")].map {|path| File.basename(path)}.first
 
     moderators = nil
     modtime = nil

--- a/www/roster/models/nonpmc.rb
+++ b/www/roster/models/nonpmc.rb
@@ -21,7 +21,7 @@ class NonPMC
     end
 
     image_dir = ASF::SVN.find('site-img') # Probably not relevant to nonPMCS; leave for now
-    image = Dir[File.join(image_dir, "#{id}.*")].map {|path| File.basename(path)}.last
+    image = Dir[File.join(image_dir, "#{id}*.{svg,eps,ai,pdf}")].map {|path| File.basename(path)}.first
 
     moderators = nil
     modtime = nil

--- a/www/roster/views/nonpmc/main.js.rb
+++ b/www/roster/views/nonpmc/main.js.rb
@@ -33,7 +33,7 @@ class NonPMC < Vue
       _a @nonpmc.display_name, href: @nonpmc.site
       _small " established #{@nonpmc.established}" if @nonpmc.established
       if @nonpmc.image
-        _img src: "https://apache.org/img/#{@nonpmc.image}"
+        _img src: "https://apache.org/logos/res/#{@nonpmc.id}/default.png"
       end
     end
 

--- a/www/roster/views/pmc/main.js.rb
+++ b/www/roster/views/pmc/main.js.rb
@@ -39,7 +39,7 @@ class PMC < Vue
       _a @committee.display_name, href: @committee.site
       _small " established #{@committee.established}" if @committee.established
       if @committee.image
-        _img src: "https://apache.org/img/#{@committee.image}"
+        _img src: "https://apache.org/logos/res/#{@committee.id}/default.png"
       end
     end
 


### PR DESCRIPTION
As requested per [WHIMSY-314](https://issues.apache.org/jira/browse/WHIMSY-314) apache.org/img/ has been replaced with apache.org/logos/