### PR TITLE
The file format changed in 2020, and this matches the new format

### DIFF
--- a/www/members/watch.cgi
+++ b/www/members/watch.cgi
@@ -38,6 +38,7 @@ _html do
     txt = File.read(File.join(meeting, 'nominated-members.txt'))
     nominations = txt.scan(/^---+\n\s*\w+.*<(\S+)@apache.org>/).flatten
     nominations += txt.scan(/^---+\n\s*\w+.*\(([a-z]+)\)/).flatten
+    nominations += txt.scan(/^---+\n+\s*([a-z]+)\s/).flatten
     nominations += txt.scan(/^---+\n\s*\w+.*\(([a-z]+)@apache\.org\)/).flatten
 
     # determine which list to report on, based on the URI


### PR DESCRIPTION
nominated-members.txt changed format between 2019 and 2020 (I don't know why) to list userid first, and then full name. This matches the new format. 

Note that this will also match previous year's file format, but INCORRECTLY. ie, will assume that person's first name is their availid.

So, in summary, changing the file format was probably a bad move, and maybe reverting THAT is actually the correct fix here.