### PR TITLE
Fixes regex to match the new format of the nominated-members.txt file

### DIFF
--- a/www/members/nominations.cgi
+++ b/www/members/nominations.cgi
@@ -37,7 +37,7 @@ def setup_data(cur_mtg_dir)
 
   # parse nominations for names and ids
   nominations = IO.read(File.join(cur_mtg_dir, 'nominated-members.txt').untaint).
-    scan(/^---+--\s+(?:[a-z]+)\s+(.*?)\n/).flatten
+    scan(/^---+--\s+(?:[a-z]+)\s+(.*?):?\n/).flatten
 
   nominations.shift if nominations.first == '<empty line>'
   nominations.pop if nominations.last.empty?

--- a/www/members/nominations.cgi
+++ b/www/members/nominations.cgi
@@ -37,7 +37,7 @@ def setup_data(cur_mtg_dir)
 
   # parse nominations for names and ids
   nominations = IO.read(File.join(cur_mtg_dir, 'nominated-members.txt').untaint).
-    scan(/^---+--\s+([a-z]+)\s+(.*?)\n/).flatten
+    scan(/^---+--\s+(?:[a-z]+)\s+(.*?)\n/).flatten
 
   nominations.shift if nominations.first == '<empty line>'
   nominations.pop if nominations.last.empty?

--- a/www/members/nominations.cgi
+++ b/www/members/nominations.cgi
@@ -37,7 +37,7 @@ def setup_data(cur_mtg_dir)
 
   # parse nominations for names and ids
   nominations = IO.read(File.join(cur_mtg_dir, 'nominated-members.txt').untaint).
-    scan(/^---+--\s+(.*?)\n/).flatten
+    scan(/^---+--\s+([a-z]+)\s+(.*?)\n/).flatten
 
   nominations.shift if nominations.first == '<empty line>'
   nominations.pop if nominations.last.empty?


### PR DESCRIPTION
Fixes regex to match the new format of the nominated-members.txt file. Specifically, since we now have "availaid FNAME LNAME:" we need to discard the availid to match the email subject line, and (maybe?) the ":" from the end of the line.

Again ... why did we change the file format?