### PR TITLE
add emeritus files and emeritus-request files to member info

### DIFF
--- a/lib/whimsy/asf/documents.rb
+++ b/lib/whimsy/asf/documents.rb
@@ -107,6 +107,33 @@ module ASF
       _, list = ASF::SVN.getlisting('emeritus-requests-received')
       list
     end
+
+    def self.find(name)
+      files = self.listnames
+      if files
+        stem = name.downcase.gsub(' ','-')
+        files.each do |file|
+          break file if file =~ stem
+        end
+      end
+    end
+  end
+
+  class EmeritusFiles
+    def self.listnames
+      _, list = ASF::SVN.getlisting('emeritus')
+      list
+    end
+
+    def self.find(name)
+      files = self.listnames
+      if files
+        stem = name.downcase.gsub(' ','-')
+        files.each do |file|
+          break file if file =~ stem
+        end
+      end
+    end
   end
 
 end

--- a/lib/whimsy/asf/documents.rb
+++ b/lib/whimsy/asf/documents.rb
@@ -102,23 +102,6 @@ module ASF
     end
   end
 
-  class EmeritusRequestFiles
-    def self.listnames
-      _, list = ASF::SVN.getlisting('emeritus-requests-received')
-      list
-    end
-
-    def self.find(name)
-      files = self.listnames
-      if files
-        stem = name.downcase.gsub(' ','-')
-        files.each do |file|
-          break file if file =~ stem
-        end
-      end
-    end
-  end
-
   class EmeritusFiles
     def self.listnames
       _, list = ASF::SVN.getlisting('emeritus')
@@ -134,6 +117,14 @@ module ASF
         end
       end
     end
+  end
+
+  class EmeritusRequestFiles < EmeritusFiles
+    def self.listnames
+      _, list = ASF::SVN.getlisting('emeritus-requests-received')
+      list
+    end
+
   end
 
 end

--- a/lib/whimsy/asf/documents.rb
+++ b/lib/whimsy/asf/documents.rb
@@ -110,12 +110,17 @@ module ASF
 
     def self.find(name)
       files = self.listnames
+      result = nil
       if files
-        stem = name.downcase.gsub(' ','-')
+        stem = Regexp.new Regexp.quote name.downcase.gsub(' ','-')
         files.each do |file|
-          break file if file && file =~ stem
+          if stem =~ file
+            result = file
+            break
+          end
         end
       end
+      return result
     end
   end
 

--- a/lib/whimsy/asf/documents.rb
+++ b/lib/whimsy/asf/documents.rb
@@ -113,7 +113,7 @@ module ASF
       if files
         stem = name.downcase.gsub(' ','-')
         files.each do |file|
-          break file if file =~ stem
+          break file if file && file =~ stem
         end
       end
     end

--- a/repository.yml
+++ b/repository.yml
@@ -78,6 +78,16 @@
     depth: delete
     list: true
 
+  emeritus:
+    url: private/documents/emeritus
+    depth: delete
+    list: true
+
+  emeritus-requests-received:
+    url: private/documents/emeritus-requests-received
+    depth: delete
+    list: true
+
   incubator-podlings:
     url: asf/incubator/public/trunk/content/podlings
     depth: files

--- a/www/roster/models/committer.rb
+++ b/www/roster/models/committer.rb
@@ -140,6 +140,13 @@ class Committer
           file = ASF::MemApps.find1st(person)
           response[:forms][:member] = file if file 
         end
+
+        file = ASF::EmeritusFiles.find(person.name)
+        response[:forms][:emeritus] = file if file
+
+        file = ASF::EmeritusRequestFiles.find(person.name)
+        response[:forms][:emeritus-request] = file if file
+
       else
         if person.member_nomination
           member[:nomination] = person.member_nomination

--- a/www/roster/models/committer.rb
+++ b/www/roster/models/committer.rb
@@ -140,11 +140,12 @@ class Committer
           file = ASF::MemApps.find1st(person)
           response[:forms][:member] = file if file 
         end
+        person_name = person.attrs['cn'].first.force_encoding('utf-8')
 
-        file = ASF::EmeritusFiles.find(person.name)
+        file = ASF::EmeritusFiles.find(person_name)
         response[:forms][:emeritus] = file if file
 
-        file = ASF::EmeritusRequestFiles.find(person.name)
+        file = ASF::EmeritusRequestFiles.find(person_name)
         response[:forms][:emeritus-request] = file if file
 
       else

--- a/www/roster/models/committer.rb
+++ b/www/roster/models/committer.rb
@@ -146,7 +146,7 @@ class Committer
         response[:forms][:emeritus] = file if file
 
         file = ASF::EmeritusRequestFiles.find(person_name)
-        response[:forms][:emeritus-request] = file if file
+        response[:forms][:emeritus_request] = file if file
 
       else
         if person.member_nomination

--- a/www/roster/views/person/forms.js.rb
+++ b/www/roster/views/person/forms.js.rb
@@ -26,10 +26,28 @@ class PersonForms < Vue
             elsif form == 'member'
               _li do
                 if link == '' # has form but no karma to view it
-                  _ 'Membership App'
+                  _ 'Member App'
                 else
-                  _a 'Membership App',
+                  _a 'Member App',
                     href: "#{documents}/member_apps/#{link}"
+                end
+              end
+            elsif form == 'emeritus'
+              _li do
+                if link == '' # has form but no karma to view it
+                  _ 'Emeritus'
+                else
+                  _a 'Emeritus',
+                    href: "#{documents}/emeritus/#{link}"
+                end
+              end
+            elsif form == 'emeritus_request'
+              _li do
+                if link == '' # has form but no karma to view it
+                  _ 'Emeritus Request'
+                else
+                  _a 'Emeritus Request',
+                    href: "#{documents}/emeritus-requests-received/#{link}"
                 end
               end
             else


### PR DESCRIPTION
The roster entry for a member currently includes links to two files: the ICLA as originally filed, and the Member Application. Since they are links, they might be directories or pdf files.

This pull request (not tested) attempts to add any files either in the emeritus directory or the emeritus-requests-received directory that matches the member's name.
