### PR TITLE
Tentative fix for 'ensure' keyword error

### DIFF
--- a/www/board/agenda/models/agenda.rb
+++ b/www/board/agenda/models/agenda.rb
@@ -151,6 +151,7 @@ class Agenda
       else
         creds = {}
       end
+    end
 
     file.untaint if file =~ /\Aboard_\w+_[\d_]+\.txt\z/
 


### PR DESCRIPTION
...I have no way to test that fix right now, just playing it by ear

https://whimsy.apache.org/board/agenda/ currently says

    x1/srv/whimsy/www/board/agenda/models/agenda.rb:216: syntax error,
    unexpected keyword_ensure, expecting keyword_end
    ensure
        ^