### PR TITLE
change agenda minuted adjournment time to UTC

### DIFF
--- a/www/board/agenda/models/minutes.rb
+++ b/www/board/agenda/models/minutes.rb
@@ -134,18 +134,12 @@ class Minutes
         if title =~ /Action Items/
           comments = notes.gsub(/\r\n/,"\n").gsub(/^/,'    ')
         elsif title == 'Adjournment'
-          if notes =~ /^1[01]:\d\d/
-            comments = "\n    Adjourned at #{notes} a.m. (Pacific)\n"
-          elsif notes =~ /^\d\d:\d\d/
-            comments = "\n    Adjourned at #{notes} p.m. (Pacific)\n"
-          else
-            comments += "\n" + notes.to_s.reflow(4,68) + "\n"
-          end
+          comments = "\n    Adjourned at #{notes} UTC\n"
         else
           comments += "\n" + notes.to_s.reflow(4,68) + "\n"
         end
       elsif title == 'Adjournment'
-        comments = "\n    Adjourned at ??:?? a.m. (Pacific)\n"
+        comments = "\n    Adjourned at ??:?? UTC\n"
       end
       [attach, title, comments]
     end

--- a/www/board/agenda/spec/secretary_spec.rb
+++ b/www/board/agenda/spec/secretary_spec.rb
@@ -83,7 +83,7 @@ feature 'report' do
       expect(draft).to include('@Sam: Is anyone on the PMC looking at the reminders?')
       expect(draft).to include('No report was submitted.')
       expect(draft).to include('was approved by Unanimous Vote of the directors present.')
-      expect(draft).to match(/Adjourned at \d+:\d\d [ap]\.m\. \(Pacific\)/)
+      expect(draft).to match(/Adjourned at \d+:\d\d UTC/)
 
       @agenda = 'board_agenda_2015_02_18.txt'
       @message = 'Draft minutes for 2015-02-18'

--- a/www/board/agenda/test/data/board_minutes_2015_01_21.txt
+++ b/www/board/agenda/test/data/board_minutes_2015_01_21.txt
@@ -859,7 +859,7 @@
 
 13. Adjournment
 
-    Adjourned at 11:34 a.m. (Pacific)
+    Adjourned at 11:34 UTC
 
 ============
 ATTACHMENTS:


### PR DESCRIPTION
This should change the minuted agenda time so that it is marked as UTC instead of Pacific. Note that the secretary is already recording the time as UTC, so we don't need to change the time digits.

I have not tested it, since I don't have a test setup, but my imagination says it will work just fine. YMMV.