### PR TITLE
Update icla-invalid-id.erb

### DIFF
--- a/www/secretary/workbench/templates/icla-invalid-id.erb
+++ b/www/secretary/workbench/templates/icla-invalid-id.erb
@@ -6,13 +6,17 @@ With this message, <%= @notify %> been notified that your ICLA has been filed.
 
 ** Please contact the <%= @cttee %> with any further questions, not the Secretary. Thanks. **
 
-Please provide the <%= @cttee %> (copied) with a valid Apache id. 
+The id you requested (<%= @user %>) is not available. 
 
-The id must not already be in use. See https://people.apache.org/committer-index.html
-Note that some existing ids include '-' and '_'. These characters are no longer permitted in ids.
+Please provide the <%= @cttee %> (copied) with a valid Apache id. They can then request your account using whimsy.
+You can provide more than one id in case your next choice is also unavailable.
 
 The id must consist of lowercase alphanumeric characters only, starting with an alphabetic character.
 Minimum length 3 characters. No special characters.
+
+The id must not already be in use. See https://people.apache.org/committer-index.html
+Note that some existing ids include '-' and '_'. These characters are no longer permitted in ids.
+Some ids are not available because they are reserved for administrative use or are assigned to inactive accounts.
 
 Warm Regards,
 

--- a/www/secretary/workbench/templates/icla-invalid-id.erb
+++ b/www/secretary/workbench/templates/icla-invalid-id.erb
@@ -8,7 +8,7 @@ With this message, <%= @notify %> been notified that your ICLA has been filed.
 
 The id you requested (<%= @user %>) is not available. 
 
-Please provide the <%= @cttee %> (copied) with a valid Apache id. They can then request your account using whimsy.
+Please provide the <%= @cttee %> (copied) with a valid Apache id. They can then request your account using Whimsy.
 You can provide more than one id in case your next choice is also unavailable.
 
 The id must consist of lowercase alphanumeric characters only, starting with an alphabetic character.


### PR DESCRIPTION
Add text to submitter acknowledgement email for invalid requested id. The id might be unavailable even though it does not contain any special characters and is not listed in the public committer-index web page.