### PR TITLE
Make users buffer fully thread-safe

### DIFF
--- a/www/board/agenda/daemon/channel.rb
+++ b/www/board/agenda/daemon/channel.rb
@@ -15,7 +15,7 @@ require 'whimsy/asf/svn'
 
 class Channel
   @@sockets = Concurrent::Map.new
-  @@users = Concurrent::Map.new {|map,key| map[key]=[]}
+  @@users = Concurrent::Map.new {|map,key| map.compute_if_absent(key) { [] } }
 
   begin
     FOUNDATION_BOARD = ASF::SVN['foundation_board']


### PR DESCRIPTION
Under intense threading usage, the `@@users` buffer will not be thread-safe fully. Details here:

ref https://github.com/ruby-concurrency/concurrent-ruby/issues/970