### PR TITLE
Update index.html

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -86,7 +86,7 @@
         </header>
           <p>The <a href="https://whimsical.apache.org/">Apache Whimsy PMC</a> manages this server, and maintains the tools here.
              Our focus is on providing organizational information about the ASF and our projects
-             in easy to consume ways, and to help automate corporate processes at the ASF to
+             in easy to consume ways, and helping to automate corporate processes at the ASF to
              make the paperwork behind the scenes easier for our many volunteers.
              Please see the Code, Questions, or Issues links above to learn more about the project.
           </p>
@@ -100,11 +100,11 @@
             </div>
             <div class="panel-body">
               <ul>
-                <li><a href="board/minutes/">Board Minutes Collated by PMC/officer/topic</a></li>
+                <li><a href="board/minutes/">Board minutes collated by PMC/officer/topic</a></li>
                 <li><a href="incubator/podlings/by-age">Incubator podlings by age</a></li>
                 <li><a href="public/">Generated JSON data files</a></li>
-                <li><a href="site/">TLP Website Checks</a></li>
-                <li><a href="pods/">Podling Website Checks</a></li>
+                <li><a href="site/">TLP website checks</a></li>
+                <li><a href="pods/">Podling website checks</a></li>
               </ul>
             </div>
           </div>
@@ -117,10 +117,10 @@
             <div class="panel-body">
               <ul>
                 <li><a href="https://selfserve.apache.org/">ASF Self-Service Platform</a></li>
-                <li><a href="https://projects.apache.org/">Apache Project Listing</a></li>
-                <li><a href="https://www.apache.org/dev">Apache Developer How-Tos</a></li>
-                <li><a href="https://community.apache.org/">Apache Community How-Tos</a></li>
-                <li><a href="https://infra.apache.org/">Apache Infra Reference Library</a></li>
+                <li><a href="https://projects.apache.org/">Apache Project listing</a></li>
+                <li><a href="https://www.apache.org/dev">Apache Developer how-tos</a></li>
+                <li><a href="https://community.apache.org/">Apache Community how-tos</a></li>
+                <li><a href="https://infra.apache.org/">Apache Infrastructure information</a></li>
               </ul>
             </div>
           </div>
@@ -130,7 +130,7 @@
         <div class="col-md-6">
           <div class="panel panel-info">
             <div class="panel-heading">
-              <h3 class="panel-title">Available To Committers</h3>
+              <h3 class="panel-title">Available to Committers</h3>
             </div>
             <div class="panel-body">
               <ul>
@@ -139,19 +139,19 @@
                   including:
                   <a href="roster/committee/">PMCs</a>
                   |
-                  <a href="roster/nonpmc/">other committees</a>
+                  <a href="roster/nonpmc/">Other committees</a>
                   |
-                  <a href="roster/ppmc/">podlings</a>
+                  <a href="roster/ppmc/">Podlings</a>
                   |
-                  <a href="roster/group/">groups</a>
+                  <a href="roster/group/">Groups</a>
                   |
-                  <a href="roster/members">members</a>
+                  <a href="roster/members">Members</a>
                   |
-                  <a href="roster/committer/">committers</a>
+                  <a href="roster/committer/">Committers</a>
                 </li>
-                <li><a href="committers/subscribe">Subscribe and unsubscribe from mailing lists</a></li>
+                <li><a href="committers/subscribe">Subscribe to and unsubscribe from mailing lists</a></li>
                 <li><a href="committers/moderationhelper">Helper for mailing list moderators (Beta)</a></li>
-                <li><a href="committers/tools">Listing of more Whimsy Tools</a></li>
+                <li><a href="committers/tools">More Whimsy Tools</a></li>
               </ul>
             </div>
           </div>
@@ -159,16 +159,16 @@
         <div class="col-md-6">
           <div class="panel panel-info">
             <div class="panel-heading">
-              <h3 class="panel-title">Tools Restricted To Officers Or Members</h3>
+              <h3 class="panel-title">Tools Restricted to Officers or Members</h3>
             </div>
             <div class="panel-body">
               <ul>
                 <li><a href="board/agenda/">Board Agenda</a></li>
                 <li><a href="https://svn.apache.org/repos/private/committers/board/calendar.txt">Board Meeting Calendar</a></li>
-                <li><a href="members/meeting.cgi">Member's Meeting Information</a></li>
+                <li><a href="members/meeting.cgi">Members' Meeting Information</a></li>
                 <li><a href="/officers/unlistedclas.cgi">Persons with signed CLAs but who are not (yet) committers.</a></li>
-                <li><a href="officers">Overview Of Useful Officer Tools</a></li>
-                <li><a href="members">Overview Of Useful Member Tools</a></li>
+                <li><a href="officers">Useful Officer Tools</a></li>
+                <li><a href="members">Useful Member Tools</a></li>
               </ul>
             </div>
           </div>
@@ -202,7 +202,7 @@
     <div class="footer container-fluid">
       <div class="panel panel-default">
         <div class="panel-heading">
-          <h3 class="panel-title">License And Credits</h3>
+          <h3 class="panel-title">License and Credits</h3>
         </div>
         <div class="panel-body">
           <p>
@@ -211,7 +211,7 @@
             |
             <a href="https://www.apache.org/foundation/policies/privacy">Privacy Policy</a>
             <br />
-          Apache&reg;, the names of Apache projects, and the feather logo are either <a href="http://www.apache.org/foundation/marks/list/">registered trademarks or trademarks</a> of the Apache Software Foundation in the United States and/or other countries.
+          Apache&reg;, the names of Apache projects, and the feather logo are either <a href="http://www.apache.org/foundation/marks/list/">registered trademarks or trademarks</a> of The Apache Software Foundation in the United States and/or other countries.
           </p>
         </div>
       </div>


### PR DESCRIPTION
line 89: change the verb to 'helping' to match 'providing' on line 88
lines 103-107 and 119-123: list is a mix of title case and sentence case. Made everything sentence case (in general, the more capital letters, the harder it is to read the thing quickly)
line 123: infra.a.o is rather more than a reference library
line 133: To ==> to
lines 142-150: capitalize first letter in each item
line 152: add missing word "to"
line 154: simplify the text of the option
line 162: Lower-case minor words
line 168: Member's ==> Members'
lines 170-171: simplify the text of the options
line 205: lower-case minor word
line 214: the ==> The, as it is part of the Foundation's name