### PR TITLE
Fix HTML syntax in `www/technology.html`

### DIFF
--- a/www/technology.html
+++ b/www/technology.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
@@ -60,10 +59,9 @@
         <ul>
           <li>Get the source:
             <a href="https://gitbox.apache.org/repos/asf/whimsy.git">Apache</a>
-            <a href="https://github.com/apache/whimsy">GitHub</a></li>
-            -
-            <a href="https://matt.apache.org/pushlogs.html?repo=whimsy">Push logs</a></li>
+            <a href="https://github.com/apache/whimsy">GitHub</a>
           </li>
+          <li><a href="https://matt.apache.org/pushlogs.html?repo=whimsy">Push logs</a></li>
           <li><a href="https://issues.apache.org/jira/browse/WHIMSY/">Issue Tracker</a></li>
           <li><a href="https://github.com/apache/whimsy/blob/master/README.md">README</a></li>
           <li><a href="docs/api/">API documentation</a></li>


### PR DESCRIPTION
View the source in desktop Linux Firefox and you see the incorrect HTML markup in `red underlined` and it also shows in IntelliJ IDE.

view-source:https://whimsy.apache.org/technology

We should use valid HTML.

Shows like this:

![Screenshot from 2024-02-22 06-47-01](https://github.com/apache/whimsy/assets/418747/f4994e03-c405-4b63-bd28-7ad043818261)
