### PR TITLE
misc: foundation fixes; add missing HTML

### DIFF
--- a/www/foundation/index.html
+++ b/www/foundation/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
-  <title>Foundation Index</title>
+  <head>
+    <title>Foundation Index</title>
+  </head>
   <body>
     <p>Nothing to see here ...</p>
     <p>Try the <a href="/foundation/orgchart/">Foundation Organisation chart</a> instead</p>

--- a/www/foundation/orgchart.cgi
+++ b/www/foundation/orgchart.cgi
@@ -31,9 +31,11 @@ def emit_orgchart(org: {})
   ) do
     _table.table.table_striped do
       _thead do
-        _th 'Title / Role'
-        _th 'Contact, Chair, or Person holding that title'
-        _th 'Website'
+        _tr_ do
+          _th 'Title / Role'
+          _th 'Contact, Chair, or Person holding that title'
+          _th 'Website'
+        end
       end
       _tbody do
         org.sort_by {|key, value| value['info']['role']}.each do |key, value|


### PR DESCRIPTION
When viewing the source of:

view-source:https://whimsy.apache.org/foundation/orgchart/

it shows the incorrect HTML as red underlined


![Screenshot from 2024-02-22 21-37-12](https://github.com/apache/whimsy/assets/418747/0c220bfc-731f-43ce-aecb-97a5b3a2c876)
