### PR TITLE
Update add comment label display

### DIFF
--- a/www/board/agenda/views/buttons/add-comment.js.rb
+++ b/www/board/agenda/views/buttons/add-comment.js.rb
@@ -35,7 +35,7 @@ class AddComment < Vue
       end
 
       #input field: initials
-      _input.comment_initials! label: 'Initials',
+      _input.comment_initials! label: 'Apache ID',
         placeholder: 'initials', disabled: @disabled,
         value: @@server.pending.initials || @@server.initials
 


### PR DESCRIPTION
Updating the displayed field description to match reality; we switched away from initials to using Apache IDs a while back.