### PR TITLE
Remove display of githubUsername per request: @Humbedooh

### DIFF
--- a/www/roster/views/committerSearch.js.rb
+++ b/www/roster/views/committerSearch.js.rb
@@ -51,7 +51,6 @@ class CommitterSearch < Vue
             person.id.include? part or
             person.name.downcase().include? part or
             person.mail.any? {|mail| mail.include? part} or
-            person.githubUsername.any? {|ghun| ghun.downcase().include? part}
           else
             person.name.downcase().include? part or
             person.mail.include? part
@@ -101,7 +100,6 @@ class CommitterSearch < Vue
                 _th 'id'
                 _th 'public name'
                 _th 'email'
-                _th 'githubUsername'
                 if @@notinavail
                   _th 'ICLA'
                 end
@@ -133,11 +131,6 @@ class CommitterSearch < Vue
                     _td person.mail
                   end
 
-                  if person.githubUsername
-                    _td person.githubUsername.join(', ')
-                  else
-                    _td ''
-                  end
                   if @@notinavail
                     # iclapath already ends in /
                     _td { _a person.claRef, href: "#{@@iclapath}#{person.iclaFile}" }

--- a/www/roster/views/nonpmc/committers.js.rb
+++ b/www/roster/views/nonpmc/committers.js.rb
@@ -22,7 +22,6 @@ class NonPMCCommitters < Vue
           _tr do
             _th if @@auth
             _th 'id', data_sort: 'string'
-            _th 'githubUsername', data_sort: 'string'
             _th.sorting_asc 'public name', data_sort: 'string-ins'
           end
         end
@@ -72,11 +71,9 @@ class NonPMCCommitter < Vue
 
       if @@person.member == true # full member
         _td { _b { _a @@person.id, href: "committer/#{@@person.id}"} }
-        _td @@person.githubUsername
         _td { _b @@person.name }
       elsif @@person.member
         _td { _i { _a @@person.id, href: "committer/#{@@person.id}"} }
-        _td @@person.githubUsername
         _td { _i @@person.name
           _ ' ('
           _ @@person.member.sub(%r{( \(Non-voting\))? Member}, '').sub(%r{^Emeritus}, 'ASF Emeritus')
@@ -84,7 +81,6 @@ class NonPMCCommitter < Vue
         }
       else
         _td { _a @@person.id, href: "committer/#{@@person.id}" }
-        _td @@person.githubUsername
         _td @@person.name
       end
     end

--- a/www/roster/views/nonpmc/members.js.rb
+++ b/www/roster/views/nonpmc/members.js.rb
@@ -19,7 +19,6 @@ class NonPMCMembers < Vue
         _tr do
           _th if @@auth
           _th 'id', data_sort: 'string'
-          _th 'githubUsername', data_sort: 'string'
           _th.sorting_asc 'public name', data_sort: 'string-ins'
           _th 'starting date', data_sort: 'string'
           _th 'status - click cell for actions', data_sort: 'string'
@@ -73,11 +72,9 @@ class NonPMCMember < Vue
 
       if @@person.member == true # full member
         _td { _b { _a @@person.id, href: "committer/#{@@person.id}"} }
-        _td @@person.githubUsername
         _td { _b @@person.name }
       elsif @@person.member
         _td { _i { _a @@person.id, href: "committer/#{@@person.id}"} }
-        _td @@person.githubUsername
         _td { _i @@person.name
           _ ' ('
           _ @@person.member.sub(%r{( \(Non-voting\))? Member}, '').sub(%r{^Emeritus}, 'ASF Emeritus')
@@ -85,7 +82,6 @@ class NonPMCMember < Vue
         }
       else
         _td { _a @@person.id, href: "committer/#{@@person.id}" }
-        _td @@person.githubUsername
         _td @@person.name
       end
 

--- a/www/roster/views/person/github.js.rb
+++ b/www/roster/views/person/github.js.rb
@@ -8,7 +8,7 @@ class PersonGitHub < Vue
 
     _div.row data_edit: 'github' do
       _div.name do
-        _ 'GitHub username(s) (user-provided)'
+        _ 'FIELD OBSOLETE: see instead: https://gitbox.apache.org/boxer/'
         _br
         _a 'Link GitHub username to ASF id', href: 'https://gitbox.apache.org/boxer/'
       end
@@ -56,4 +56,3 @@ class PersonGitHub < Vue
     end
   end
 end
-

--- a/www/roster/views/pmc/committers.js.rb
+++ b/www/roster/views/pmc/committers.js.rb
@@ -22,7 +22,6 @@ class PMCCommitters < Vue
           _tr do
             _th if @@auth
             _th 'id', data_sort: 'string'
-            _th 'githubUsername', data_sort: 'string'
             _th.sorting_asc 'public name', data_sort: 'string-ins'
           end
         end
@@ -72,11 +71,9 @@ class PMCCommitter < Vue
 
       if @@person.member == true # full member
         _td { _b { _a @@person.id, href: "committer/#{@@person.id}"} }
-        _td @@person.githubUsername
         _td { _b @@person.name }
       elsif @@person.member
         _td { _i { _a @@person.id, href: "committer/#{@@person.id}"} }
-        _td @@person.githubUsername
         _td { _i @@person.name
           _ ' ('
           _ @@person.member.sub(%r{( \(Non-voting\))? Member}, '').sub(%r{^Emeritus}, 'ASF Emeritus')
@@ -84,7 +81,6 @@ class PMCCommitter < Vue
         }
       else
         _td { _a @@person.id, href: "committer/#{@@person.id}" }
-        _td @@person.githubUsername
         _td @@person.name
       end
     end

--- a/www/roster/views/pmc/members.js.rb
+++ b/www/roster/views/pmc/members.js.rb
@@ -16,7 +16,6 @@ class PMCMembers < Vue
         _tr do
           _th if @@auth
           _th 'id', data_sort: 'string'
-          _th 'githubUsername', data_sort: 'string'
           _th.sorting_asc 'public name', data_sort: 'string-ins'
           _th 'starting date', data_sort: 'string'
           _th 'status - click cell for actions', data_sort: 'string'
@@ -182,13 +181,11 @@ class PMCMember < Vue
         _td { _b { _a @@person.id, href: "committer/#{@@person.id}", style: style }
               _a ' (*)', href: "committee/#{@@committee.id}#crosscheck", style: style if @@person.notSubbed
             }
-        _td @@person.githubUsername, style: style
         _td { _b @@person.name, style: style }
       elsif @@person.member
         _td { _i { _a @@person.id, href: "committer/#{@@person.id}", style: style }
               _a ' (*)', href: "committee/#{@@committee.id}#crosscheck", style: style if @@person.notSubbed
             }
-        _td @@person.githubUsername, style: style
         _td { _i @@person.name, style: style
               _ ' ('
               _ @@person.member.sub(%r{( \(Non-voting\))? Member}, '').sub(%r{^Emeritus}, 'ASF Emeritus'), style: style
@@ -198,7 +195,6 @@ class PMCMember < Vue
         _td { _a @@person.id, href: "committer/#{@@person.id}", style: style
               _a ' (*)', href: "committee/#{@@committee.id}#crosscheck", style: style if @@person.notSubbed
             }
-        _td @@person.githubUsername, style: style
         _td @@person.name, style: style
       end
 

--- a/www/roster/views/ppmc/committers.js.rb
+++ b/www/roster/views/ppmc/committers.js.rb
@@ -26,7 +26,6 @@ class PPMCCommitters < Vue
           _tr do
             _th if @@auth.ppmc
             _th 'id', data_sort: 'string'
-            _th 'githubUsername', data_sort: 'string'
             _th.sorting_asc 'public name', data_sort: 'string-ins'
             _th 'notes'
           end
@@ -99,11 +98,9 @@ class PPMCCommitter < Vue
 
       if @@person.member == true # full member
         _td { _b { _a @@person.id, href: "committer/#{@@person.id}"} }
-        _td @@person.githubUsername
         _td { _b @@person.name }
       elsif @@person.member
         _td { _i { _a @@person.id, href: "committer/#{@@person.id}"} }
-        _td @@person.githubUsername
         _td { _i @@person.name
           _ ' ('
           _ @@person.member.sub(%r{( \(Non-voting\))? Member}, '').sub(%r{^Emeritus}, 'ASF Emeritus')
@@ -111,7 +108,6 @@ class PPMCCommitter < Vue
         }
       else
         _td { _a @@person.id, href: "committer/#{@@person.id}" }
-        _td @@person.githubUsername
         _td @@person.name
       end
 

--- a/www/roster/views/ppmc/members.js.rb
+++ b/www/roster/views/ppmc/members.js.rb
@@ -11,7 +11,6 @@ class PPMCMembers < Vue
         _tr do
           _th if @@auth.ppmc
           _th 'id', data_sort: 'string'
-          _th 'githubUsername', data_sort: 'string'
           _th.sorting_asc 'public name', data_sort: 'string-ins'
           _th 'notes'
         end
@@ -137,13 +136,11 @@ class PPMCMember < Vue
         _td { _b { _a @@person.id, href: "committer/#{@@person.id}" }
               _a ' (*)', href: "ppmc/#{@@ppmc.id}#crosscheck" if @@person.notSubbed
             }
-        _td @@person.githubUsername
         _td { _b @@person.name }
       elsif @@person.member
         _td { _i { _a @@person.id, href: "committer/#{@@person.id}" }
               _a ' (*)', href: "ppmc/#{@@ppmc.id}#crosscheck" if @@person.notSubbed
             }
-        _td @@person.githubUsername
         _td { _i @@person.name
               _ ' ('
               _ @@person.member.sub(%r{( \(Non-voting\))? Member}, '').sub(%r{^Emeritus}, 'ASF Emeritus')
@@ -153,7 +150,6 @@ class PPMCMember < Vue
         _td { _a @@person.id, href: "committer/#{@@person.id}"
               _a ' (*)', href: "ppmc/#{@@ppmc.id}#crosscheck" if @@person.notSubbed
             }
-        _td @@person.githubUsername
         _td @@person.name
       end
 

--- a/www/roster/views/ppmc/mentors.js.rb
+++ b/www/roster/views/ppmc/mentors.js.rb
@@ -14,7 +14,6 @@ class PPMCMentors < Vue
         _tr do
           _th if @@auth.ipmc
           _th 'id'
-          _th 'githubUsername'
           _th 'public name'
           _th 'notes'
         end
@@ -61,13 +60,11 @@ class PPMCMentor < Vue
         _td { _b { _a @@person.id, href: "committer/#{@@person.id}" }
               _a ' (*)', href: "ppmc/#{@@ppmc.id}#crosscheck" if @@person.notSubbed
             }
-        _td @@person.githubUsername
         _td { _b @@person.name }
       elsif @@person.member
         _td { _i { _a @@person.id, href: "committer/#{@@person.id}" }
               _a ' (*)', href: "ppmc/#{@@ppmc.id}#crosscheck" if @@person.notSubbed
             }
-        _td @@person.githubUsername
         _td { _i @@person.name
               _ ' ('
               _ @@person.member.sub(%r{( \(Non-voting\))? Member}, '').sub(%r{^Emeritus}, 'ASF Emeritus')
@@ -77,11 +74,9 @@ class PPMCMentor < Vue
         _td { _a @@person.id, href: "committer/#{@@person.id}"
               _a ' (*)', href: "ppmc/#{@@ppmc.id}#crosscheck" if @@person.notSubbed
             }
-        _td @@person.githubUsername
         _td @@person.name
       else
         _td @@person.id
-        _td @@person.githubUsername
         _td @@person.name
       end
 


### PR DESCRIPTION
Per the 'dooh, this attribute is no longer used, and should not be displayed.  Eventually we can remove entirely.