### PR TITLE
Make subject of board report reminders not say missing.

### DIFF
--- a/www/board/agenda/views/buttons/email.js.rb
+++ b/www/board/agenda/views/buttons/email.js.rb
@@ -45,7 +45,7 @@ class Email < Vue
     cc = "#{mail_list},#{@@item.cc}"
 
     if @@item.missing
-      subject = "Missing #{@@item.title} Board Report"
+      subject = "[REMINDER] Please submit the #{@@item.title} Board Report"
       if @@item.attach =~ /^\d/
         body = %{
           Dear #{@@item.owner},


### PR DESCRIPTION
By changing the tone of the subject reminders to submit the report are less judgmental.