### PR TITLE
support _ in addition to - for old minutes

### DIFF
--- a/tools/collate_minutes.rb
+++ b/tools/collate_minutes.rb
@@ -285,7 +285,7 @@ seen={}
     -{41}\n                        # separator
     Attachment\s\s?(\w+):[ ](.+?)\n # Attachment, Title
     (.)(.*?)\n                     # separator, report
-    (?=-{41,}\n(?:End|Attach))     # separator
+    (?=[-_]{41,}\n(?:End|Attach))     # separator
   /mx).each do |attach,title,cont,text|
 
     # We need to keep the start of the second line.


### PR DESCRIPTION
fixes #238

since end of 2003, minutes end with

```
------------------------------------------------------
End of minutes for the December 17, 2003 board meeting.
```

but previously it ended with
```
__________________________________________________________
End of minutes for the 19 Mar 2003 board meeting.
```

tested locally, it impacts a few PMCs:

```
_INFO 2025-01-26 21:43:40 +0000 Writing Ant.html
_INFO 2025-01-26 21:43:41 +0000 Writing Fundraising.html
_INFO 2025-01-26 21:43:42 +0000 Writing JAMES.html
_INFO 2025-01-26 21:43:42 +0000 Writing Jakarta.html
_INFO 2025-01-26 21:43:42 +0000 Writing Legal_Affairs.html
_INFO 2025-01-26 21:43:43 +0000 Writing Maven.html
_INFO 2025-01-26 21:43:44 +0000 Writing Security_Team.html
_INFO 2025-01-26 21:43:45 +0000 Writing Web_Services.html
```