### PR TITLE
Switch to using ruby-ldap3 to support Ruby 3.x

### DIFF
--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -15,7 +15,7 @@ run either in a local environment or with a webserver.
   - Puppet (for our [production](DEPLOYMENT.md) deployment)
 - A variety of Ruby gems
   - [Wunderbar](https://github.com/rubys/wunderbar) - HTML Generator and CGI application support
-  - [Ruby-ldap](https://github.com/bearded/ruby-ldap) - LDAP for Ruby
+  - [Ruby-ldap](https://github.com/Punderthings/ruby-ldap3) - LDAP for Ruby
   - [nokogiri](https://github.com/sparklemotion/nokogiri) - HTML parser for Ruby
   - Full gem dependencies in `asf.gemspec`
 

--- a/asf.gemspec
+++ b/asf.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   # relevant versions
   s.add_dependency('nokogiri')
   s.add_dependency('rack')
-  s.add_dependency('ruby-ldap3', '0.10.1')
+  s.add_dependency('ruby-ldap3', '0.10.2')
   s.add_dependency('tzinfo')
   s.add_dependency('tzinfo-data')
   s.add_dependency('wunderbar')

--- a/asf.gemspec
+++ b/asf.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   # relevant versions
   s.add_dependency('nokogiri')
   s.add_dependency('rack')
-  s.add_dependency('ruby-ldap3', '0.10.2')
+  s.add_dependency('ruby-ldap3', ldapversion)
   s.add_dependency('tzinfo')
   s.add_dependency('tzinfo-data')
   s.add_dependency('wunderbar')

--- a/asf.gemspec
+++ b/asf.gemspec
@@ -1,5 +1,5 @@
 version = File.read(File.expand_path('../asf.version', __FILE__)).strip
-ldapversion = 
+ldapversion =
 begin
   File.read(File.expand_path('../asfldap.version', __FILE__)).strip
 rescue Exception => e
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   # relevant versions
   s.add_dependency('nokogiri')
   s.add_dependency('rack')
-  s.add_dependency('ruby-ldap', ldapversion)
+  s.add_dependency('ruby-ldap3', '0.10.1')
   s.add_dependency('tzinfo')
   s.add_dependency('tzinfo-data')
   s.add_dependency('wunderbar')

--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -11,7 +11,7 @@ end
 gem 'json'
 gem 'nokogiri'
 gem 'rake'
-gem 'ruby-ldap3', '~> 0.10.1' # Forked version supports ruby 3.x
+gem 'ruby-ldap3', ldapversion # Forked version supports ruby 3.x
 gem 'wunderbar'
 gem 'pdf-reader'
 

--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -11,7 +11,7 @@ end
 gem 'json'
 gem 'nokogiri'
 gem 'rake'
-gem 'ruby-ldap', ldapversion
+gem 'ruby-ldap3', '~> 0.10.1' # Forked version supports ruby 3.x
 gem 'wunderbar'
 gem 'pdf-reader'
 


### PR DESCRIPTION
I _think_ we can remove the extra asfldap.version stuff now, since we (I) can now just fix the underlying ruby-ldap3 gem if there are issues in the future.