### PR TITLE
Explicitly add a seconds separator for new nominations

### DIFF
--- a/lib/whimsy/asf/member-files.rb
+++ b/lib/whimsy/asf/member-files.rb
@@ -37,6 +37,7 @@ module ASF
       \s*Nomination\ [sS]tatement:\s*?\r?\n+(?<statement>.*)\z
       }mx
 
+    SECONDS_SEPARATOR = '*** Seconds (if any; include your id) ***'
     # get the latest meeting directory or nomination file
     def self.latest_meeting(name=nil)
       if name.nil? # we want the parent directory
@@ -130,6 +131,8 @@ module ASF
         '',
         '   Nomination Statement:',
         ASFString.reflow(statement, 4, 80),
+        '',
+        SECONDS_SEPARATOR,
         ''
       ].compact.join("\n") + "\n"
     end
@@ -151,6 +154,8 @@ module ASF
         '',
         '   Nomination Statement:',
         ASFString.reflow(statement, 4, 80),
+        '',
+        SECONDS_SEPARATOR,
         ''
       ].compact.join("\n") + "\n"
     end

--- a/lib/whimsy/asf/member-files.rb
+++ b/lib/whimsy/asf/member-files.rb
@@ -37,7 +37,7 @@ module ASF
       \s*Nomination\ [sS]tatement:\s*?\r?\n+(?<statement>.*)\z
       }mx
 
-    SECONDS_SEPARATOR = '*** Seconds (if any; include your id) ***'
+    SECONDS_SEPARATOR = '*** Seconds Statements ***'
     # get the latest meeting directory or nomination file
     def self.latest_meeting(name=nil)
       if name.nil? # we want the parent directory


### PR DESCRIPTION
This is useful to make it clear to readers where an original nominator's statement ends, and any comments from seconds are. I'd appreciate a review, just to ensure it doesn't break anything different; we definitely need this separator added for our meeting process.