### PR TITLE
Remove check for project when creating new account for ICLA

### DIFF
--- a/www/secretary/workbench/views/forms/icla.js.rb
+++ b/www/secretary/workbench/views/forms/icla.js.rb
@@ -225,8 +225,6 @@ class ICLA < Vue
     project = document.querySelector('select[name=project]')
     votelink = document.querySelector('input[name=votelink]')
 
-    valid &&= project.validity.valid
-
     # project votelink are only required with valid users; only validate
     # votelink if the user is valid
     if user.validity.valid and user.value.length > 0


### PR DESCRIPTION
Current ICLA handling for new accounts requires the project be valid. This causes an issue for new members who do not have an account and thus have no project.

All other checks are left in place.