### PR TITLE
fix: board minutes collation: no longer try to reuse year

### DIFF
--- a/tools/collate_minutes.rb
+++ b/tools/collate_minutes.rb
@@ -790,13 +790,7 @@ def layout(title = nil)
 #   $calendar.at('h2').content = "Board Meeting Minutes"
   end
 
-  # Adjust the page header
-
-  # find the intro para; assume it is the first para with a strong tag
-  # then back up to the main container class for the page content
-  section = $calendar.at('.container p strong').parent.parent
-  # Extract all the paragraphs
-  paragraphs = section.search('p')
+  section = $calendar.at('#maincontent .container')
 
   # remove all the existing content
   section.children.each {|child| child.remove}
@@ -830,10 +824,6 @@ def layout(title = nil)
       end
     end
   }
-
-  # and the second para which is assumed to be the list of years
-  section.add_child paragraphs[1]
-  section.add_child "\n" # separator to make it easier to read source
 
   # now add the content provided by the builder block
   content.at('body').children.each {|child| section.add_child child}


### PR DESCRIPTION
previously, this script fetched https://www.apache.org/foundation/board/calendar.html to re-use its style and the 'list of years' paragraph.

However, presumably due to changes to calendar.html, this has been showing a random different paragraph on the minutes pages, currently 'Meeting times vary'.

Instead of being clever, I don't think we have a strong need to have that year paragraph here, so we'd be better off just replacing the main content wholesale.