### PR TITLE
Clarify intent of submitter of document

### DIFF
--- a/www/secretary/workbench/templates/clarify-intent.erb
+++ b/www/secretary/workbench/templates/clarify-intent.erb
@@ -1,6 +1,6 @@
 Dear <%= @email.display_names.join(', ') %>,
 
-We received this document but we don't know why you sent it.
+We received this document but it is not clear why you sent it.
 
 Please clarify your intent in sending this document.
 Secretary processes documents from contributors to ASF projects.

--- a/www/secretary/workbench/templates/clarify-intent.erb
+++ b/www/secretary/workbench/templates/clarify-intent.erb
@@ -1,0 +1,13 @@
+Dear <%= @email.display_names.join(', ') %>,
+
+We received this document but we don't know why you sent it.
+
+Please clarify your intent in sending this document.
+Secretary processes documents from contributors to ASF projects.
+
+For more details, please refer to the following:
+https://apache.org/licenses/contributor-agreements.html#submitting
+
+Warm Regards,
+
+<%= @sig %>

--- a/www/secretary/workbench/views/actions/clarify_intent.json.rb
+++ b/www/secretary/workbench/views/actions/clarify_intent.json.rb
@@ -1,0 +1,41 @@
+# extract message
+message = Mailbox.find(@message)
+
+# obtain per-user information
+_personalize_email(env.user)
+
+# extract/verify project
+_extract_project
+
+########################################################################
+#                           email submitter                            #
+########################################################################
+
+# send rejection email
+task "email #{message.from}" do
+  # build mail from template
+  @email = message.from
+  mail = message.reply(
+    from: @from,
+    cc: [
+      'secretary@apache.org',
+      (@pmc.private_mail_list if @pmc), # copy pmc
+      (@podling.private_mail_list if @podling) # copy podling
+    ],
+    body: template('clarify-intent.erb')
+  )
+
+  # echo email
+  form do
+    _message mail.to_s
+  end
+
+  # deliver mail
+  complete do
+    _disposition :keep # set this first in case mail sending fails
+
+    mail.deliver!
+
+    _status 'request to clarify intent has been sent.'
+  end
+end

--- a/www/secretary/workbench/views/parts.js.rb
+++ b/www/secretary/workbench/views/parts.js.rb
@@ -27,6 +27,7 @@ class Parts < Vue
     @unsigned = false
     @script_font = false
     @upload_sig = false
+    @clarify_intent = false
     @invalid_availid = false
   end
 
@@ -222,6 +223,7 @@ class Parts < Vue
             _input type: 'hidden', name: 'unsigned', value: @unsigned
             _input type: 'hidden', name: 'script_font', value: @script_font
             _input type: 'hidden', name: 'upload_sig', value: @upload_sig
+            _input type: 'hidden', name: 'clarify_intent', value: @clarify_intent
             _input type: 'hidden', name: 'invalid_availid', value: @invalid_availid
             # the above entries must agree with the checked: entries below
             # also any new entries must be added to the backend script incomplete.json.rb
@@ -359,6 +361,13 @@ class Parts < Vue
                   _input type: 'checkbox', checked: @upload_sig,
                   onClick: -> {@upload_sig = !@upload_sig}
                   _span ' upload signature'
+                end
+              end
+              _li do
+                _label do
+                  _input type: 'checkbox', checked: @clarify_intent,
+                  onClick: -> {@clarify_intent = !@uclarify_intent}
+                  _span ' clarify intent'
                 end
               end
               _li do

--- a/www/secretary/workbench/views/parts.js.rb
+++ b/www/secretary/workbench/views/parts.js.rb
@@ -27,7 +27,6 @@ class Parts < Vue
     @unsigned = false
     @script_font = false
     @upload_sig = false
-    @clarify_intent = false
     @invalid_availid = false
   end
 

--- a/www/secretary/workbench/views/parts.js.rb
+++ b/www/secretary/workbench/views/parts.js.rb
@@ -223,7 +223,6 @@ class Parts < Vue
             _input type: 'hidden', name: 'unsigned', value: @unsigned
             _input type: 'hidden', name: 'script_font', value: @script_font
             _input type: 'hidden', name: 'upload_sig', value: @upload_sig
-            _input type: 'hidden', name: 'clarify_intent', value: @clarify_intent
             _input type: 'hidden', name: 'invalid_availid', value: @invalid_availid
             # the above entries must agree with the checked: entries below
             # also any new entries must be added to the backend script incomplete.json.rb
@@ -234,6 +233,12 @@ class Parts < Vue
               _input type: 'radio', name: 'doctype', value: 'pubkey',
                 onClick: self.reject
               _span 'upload public key'
+            end
+
+            _label do
+              _input type: 'radio', name: 'doctype', value: 'clarify_intent',
+                onClick: self.reject
+              _span 'clarify intent'
             end
 
             # The reject reason list will grow, so do it last
@@ -361,13 +366,6 @@ class Parts < Vue
                   _input type: 'checkbox', checked: @upload_sig,
                   onClick: -> {@upload_sig = !@upload_sig}
                   _span ' upload signature'
-                end
-              end
-              _li do
-                _label do
-                  _input type: 'checkbox', checked: @clarify_intent,
-                  onClick: -> {@clarify_intent = !@uclarify_intent}
-                  _span ' clarify intent'
                 end
               end
               _li do


### PR DESCRIPTION
I'd like to add a new feature to secretary workbench to send email to the sender requesting clarification of the sender's intent.

I want to model this on the "upload public key" feature. Secretary can check the box and send the message. Once the user has replied the document can be processed or rejected.

I've added a checkbox and a message to the user but I'm not sure how to proceed