### PR TITLE
Adjust some phrases about Apache, ASF + "feather"

### DIFF
--- a/lib/whimsy/asf/themes.rb
+++ b/lib/whimsy/asf/themes.rb
@@ -26,7 +26,7 @@ class Wunderbar::HtmlMarkup
         _ ' | '
         _a 'Privacy Policy', href: 'https://www.apache.org/foundation/policies/privacy.html'
         _br
-        _{"Apache\u00AE, the names of Apache projects, and the multicolor feather logo are "}
+        _{"Apache\u00AE, the names of Apache projects, and the logo are "}
         _a 'registered trademarks or trademarks', href: 'https://www.apache.org/foundation/marks/list/'
         _ ' of the Apache Software Foundation in the United States and/or other countries.'
       end
@@ -99,7 +99,7 @@ class Wunderbar::HtmlMarkup
           _ul.nav.navbar_nav.navbar_right do
             _li.dropdown do
               _a.dropdown_toggle href: '#', data_toggle: 'dropdown', role: 'button', aria_haspopup: 'true', aria_expanded: 'false' do
-                _img title: 'Apache Home', alt: 'Apache feather logo', src: 'https://www.apache.org/img/feather_glyph_notm.png', height: 30
+                _img title: 'The Apache Software Foundation', alt: 'ASF logo', src: 'https://www.apache.org/img/feather_glyph_notm.png', height: 30
                 _ ' Apache'
                 _span.caret
               end

--- a/www/401.html
+++ b/www/401.html
@@ -37,7 +37,7 @@
         <ul class="nav navbar-nav navbar-right">
           <li class="dropdown">
             <a class="dropdown-toggle" href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-              <img title="Apache Home" alt="Apache feather logo" src="https://www.apache.org/img/feather_glyph_notm.png" height="30"/>
+              <img title="The Apache Software Foundation" alt="ASF logo" src="https://www.apache.org/img/feather_glyph_notm.png" height="30"/>
               Apache
               <span class="caret"></span>
             </a>
@@ -125,7 +125,7 @@
         |
         <a href="https://www.apache.org/foundation/policies/privacy.html">Privacy Policy</a>
         <br/>
-        Apache®, the names of Apache projects, and the multicolor feather logo are
+        Apache®, the names of Apache projects, and the logo are
         <a href="https://www.apache.org/foundation/marks/list/">registered trademarks or trademarks</a>
         of the Apache Software Foundation in the United States and/or other countries.
       </p>

--- a/www/404.html
+++ b/www/404.html
@@ -37,7 +37,7 @@
         <ul class="nav navbar-nav navbar-right">
           <li class="dropdown">
             <a class="dropdown-toggle" href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-              <img title="Apache Home" alt="Apache feather logo" src="https://www.apache.org/img/feather_glyph_notm.png" height="30"/>
+              <img title="The Apache Software Foundation" alt="ASF logo" src="https://www.apache.org/img/feather_glyph_notm.png" height="30"/>
               Apache
               <span class="caret"></span>
             </a>
@@ -111,7 +111,7 @@
         |
         <a href="https://www.apache.org/foundation/policies/privacy.html">Privacy Policy</a>
         <br/>
-        Apache®, the names of Apache projects, and the multicolor feather logo are
+        Apache®, the names of Apache projects, and the logo are
         <a href="https://www.apache.org/foundation/marks/list/">registered trademarks or trademarks</a>
         of the Apache Software Foundation in the United States and/or other countries.
       </p>

--- a/www/500.html
+++ b/www/500.html
@@ -37,7 +37,7 @@
         <ul class="nav navbar-nav navbar-right">
           <li class="dropdown">
             <a class="dropdown-toggle" href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-              <img title="Apache Home" alt="Apache feather logo" src="https://www.apache.org/img/feather_glyph_notm.png" height="30"/>
+              <img title="The Apache Software Foundation" alt="ASF logo" src="https://www.apache.org/img/feather_glyph_notm.png" height="30"/>
               Apache
               <span class="caret"></span>
             </a>
@@ -118,7 +118,7 @@
         |
         <a href="https://www.apache.org/foundation/policies/privacy.html">Privacy Policy</a>
         <br/>
-        Apache®, the names of Apache projects, and the multicolor feather logo are
+        Apache®, the names of Apache projects, and the logo are
         <a href="https://www.apache.org/foundation/marks/list/">registered trademarks or trademarks</a>
         of the Apache Software Foundation in the United States and/or other countries.
       </p>

--- a/www/503.html
+++ b/www/503.html
@@ -37,7 +37,7 @@
         <ul class="nav navbar-nav navbar-right">
           <li class="dropdown">
             <a class="dropdown-toggle" href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-              <img title="Apache Home" alt="Apache feather logo" src="https://www.apache.org/img/feather_glyph_notm.png" height="30"/>
+              <img title="The Apache Software Foundation" alt="ASF logo" src="https://www.apache.org/img/feather_glyph_notm.png" height="30"/>
               Apache
               <span class="caret"></span>
             </a>
@@ -118,7 +118,7 @@
         |
         <a href="https://www.apache.org/foundation/policies/privacy.html">Privacy Policy</a>
         <br/>
-        Apache®, the names of Apache projects, and the multicolor feather logo are
+        Apache®, the names of Apache projects, and the logo are
         <a href="https://www.apache.org/foundation/marks/list/">registered trademarks or trademarks</a>
         of the Apache Software Foundation in the United States and/or other countries.
       </p>

--- a/www/index.html
+++ b/www/index.html
@@ -46,7 +46,7 @@
       <div class="row">
         <div class="col-sm-4 hidden-xs">
           <a href="https://www.apache.org/">
-            <img title="The Apache Software Foundation" alt="ASF Logo" style="margin-left: 10px; margin-top: 10px;" src="https://www.apache.org/foundation/press/kit/asf_logo_small.png"/>
+            <img title="The Apache Software Foundation" alt="ASF logo" style="margin-left: 10px; margin-top: 10px;" src="https://www.apache.org/foundation/press/kit/asf_logo_small.png"/>
           </a>
         </div>
         <div class="col-sm-3 col-xs-3">
@@ -234,7 +234,7 @@
             |
             <a href="https://www.apache.org/foundation/policies/privacy.html">Privacy Policy</a>
             <br />
-          Apache&reg;, the names of Apache projects, and the feather logo are either <a href="https://www.apache.org/foundation/marks/list/">registered trademarks or trademarks</a> of The Apache Software Foundation in the United States and/or other countries.
+          Apache&reg;, the names of Apache projects, and the logo are either <a href="https://www.apache.org/foundation/marks/list/">registered trademarks or trademarks</a> of The Apache Software Foundation in the United States and/or other countries.
           </p>
         </div>
       </div>

--- a/www/project/icla/views/app.html.rb
+++ b/www/project/icla/views/app.html.rb
@@ -361,8 +361,9 @@ _html lang: 'en', _width: '80' do
               _ '.'
             end
 
-            _p.text_center 'Apache and the Apache feather logo are ' +
-              'trademarks of The Apache Software Foundation.'
+            _p.text_center 'Apache®, the names of Apache projects, and the logo are ' +
+              'either registered trademarks or trademarks of The Apache Software Foundation ' +
+              'in the United States and/or other countries.'
           end
         end
       end

--- a/www/public/HEADER.html
+++ b/www/public/HEADER.html
@@ -1,2 +1,2 @@
-<a href="http://www.apache.org/"><img alt="The Apache Software Foundation" src="https://www.apache.org/foundation/press/kit/asf_logo_small.png" title="ASF Logo"/></a>
+<a href="http://www.apache.org/"><img alt="The Apache Software Foundation" src="https://www.apache.org/foundation/press/kit/asf_logo_small.png" title="ASF logo"/></a>
 <a href="/"><img alt="whimsy" src="../whimsy.svg" title="whimsy" width="140"/></a>


### PR DESCRIPTION
* Replaces the phrase "Apache Home" with "Apache Software Foundation" in `<img title`.
* Replaces the phrase "Apache feather logo", and similar, with "ASF logo" in `<img alt`.
* Removes the phrase "multicolor feather" in footers ("Apache®, the names of Apache projects, and the multicolor feather logo are..." -> "Apache®, the names of Apache projects, and the logo are").
* Adjust the trademarks phrase in `www/project/icla/views/app.html.rb`.