### PR TITLE
[CI] Pin remaining actions to sha

### DIFF
--- a/.github/workflows/npmtest.yml
+++ b/.github/workflows/npmtest.yml
@@ -25,7 +25,7 @@ jobs:
         which -a node || true
         which -a npm || true
         echo "==================="
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: '18.16.0'
     - name: Check Path 2

--- a/.github/workflows/unittestlib.yml
+++ b/.github/workflows/unittestlib.yml
@@ -31,7 +31,7 @@ jobs:
       if: ${{ runner.os == 'macOS' }}
       run: |
         brew install subversion
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         persist-credentials: false
     - name: Fix LDAP version and install SVN if necessary
@@ -45,7 +45,7 @@ jobs:
             sudo apt-get update && sudo apt-get install -y subversion
         fi
     - name: ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true


### PR DESCRIPTION
We already pin here:

https://github.com/apache/whimsy/blob/master/.github/workflows/pre-commit.yml

https://github.com/ruby/setup-ruby/commit/afeafc3d1ab54a631816aba4c914a0081c12ff2f

https://github.com/actions/setup-node/commit/48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e

https://github.com/actions/checkout/commit/df4cb1c069e1874edd31b4311f1884172cec0e10

---

Using mutable tags like `@v4` leaves your pipelines vulnerable to supply chain attacks if a developer's account is compromised. Pinning to a unique 40-character commit SHA ensures you run immutable, unalterable code that cannot be silently modified by bad actors. This practice guarantees absolute build reproducibility because cryptographic hashes cannot be force-pushed or rewritten. It also protects your workflows from risks like repository deletion or malicious name squatting. For maximum safety, pairs SHAs with inline comments so dependency tools can still automate your version updates.