### PR TITLE
`.asf.yaml`: use a better repo description

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -5,6 +5,7 @@ notifications:
   jobs: notifications@whimsical.apache.org
   jira_options: link label
 github:
+  description: "Apache Whimsy is a collection of useful organizational tools used by the ASF and Apache committers"
   rulesets:
     - name: "Default Branch Protection"
       type: branch


### PR DESCRIPTION
We should use this space or real estate as best we can.

Currently we just have "Apache Whimsy".

Some examples:

https://github.com/apache/shiro/blob/5084e2bb1b5d540154d143701d7555abb74436ef/.asf.yaml#L20

https://github.com/apache/airflow/blob/f90ebd0835bead9b61db675009dfe8d32b575740/.asf.yaml#L30

