### PR TITLE
Add pre-commit hook gitleaks secret scanner

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,9 @@ repos:
     - id: trailing-whitespace
       files: \.(cgi|html|json|md|plist|py|rb|rdf|service|sh|template|ya?ml)$
       args: [--markdown-linebreak-ext=md]
+- repo: https://github.com/gitleaks/gitleaks
+  rev: v8.30.1
+  hooks:
+    - id: gitleaks
+      name: run gitleaks
+      description: check for secrets with gitleaks


### PR DESCRIPTION
Gitleaks is a tool for detecting secrets like passwords, API keys, and tokens in git repos, files, and whatever else you wanna throw at it via stdin.

https://github.com/gitleaks/gitleaks#pre-commit

https://gitleaks.io