### PR TITLE
Add Downloads pass/fail column to site-scan overview

### DIFF
--- a/lib/whimsy/sitestandards.rb
+++ b/lib/whimsy/sitestandards.rb
@@ -322,7 +322,7 @@ module SiteStandards
     return [
       counts, {
       SITE_PASS => '# Sites with links to primary ASF page',
-      SITE_WARN => '# Sites with link, but not an expected ASF one',
+      SITE_WARN => '# Sites with link, but not an expected ASF one, or not expected to publish downloads',
       SITE_FAIL => '# Sites with no link for this topic'
       }, success
     ]

--- a/lib/whimsy/sitewebsite.rb
+++ b/lib/whimsy/sitewebsite.rb
@@ -4,6 +4,14 @@ require 'wunderbar'
 require 'wunderbar/bootstrap'
 require_relative '../whimsy/asf/themes'
 
+# Full PMCs that intentionally don't publish releases, so an empty downloads
+# list is expected rather than a failure. Non-PMC committees (Brand
+# Management, Data Privacy, Diversity, etc.) are detected automatically via
+# the 'nonpmc' flag recorded by site-scan.rb. This small list is needed
+# because "makes releases" is not a field in committee_info; revisit if that
+# data becomes available.
+NO_RELEASES = %w(attic comdev gump whimsy).freeze
+
 # Display data for a single project's checks
 # @param project id of project
 # @param links site data for that specific project
@@ -211,15 +219,23 @@ def display_overview(sites, analysis, checks, tlp = true)
               _td '', class: cls, data_sort_value: sort_order[cls]
             end
             downloads = links['downloads'] || {}
-            if downloads.empty?
-              # No downloads discovered: flag red like other failing cells
-              cls = SiteStandards::SITE_FAIL
-              _td '', class: cls, data_sort_value: sort_order[cls]
-            else
+            # A project is expected to publish downloads unless it is a
+            # non-PMC committee or one of the few PMCs that don't release.
+            expected = !links['nonpmc'] && !NO_RELEASES.include?(n.downcase)
+            if !downloads.empty?
               cls = SiteStandards::SITE_PASS
               # Expose the discovered download URLs in a hover tooltip
               _td '', class: cls, data_sort_value: sort_order[cls],
                   title: downloads.keys.join("\n")
+            elsif expected
+              # Expected downloads but none found: flag red like other fails
+              cls = SiteStandards::SITE_FAIL
+              _td '', class: cls, data_sort_value: sort_order[cls]
+            else
+              # Not expected to publish downloads: warn (amber), not a failure
+              cls = SiteStandards::SITE_WARN
+              _td '', class: cls, data_sort_value: sort_order[cls],
+                  title: 'Not expected to publish downloads'
             end
           end
         end

--- a/lib/whimsy/sitewebsite.rb
+++ b/lib/whimsy/sitewebsite.rb
@@ -189,6 +189,10 @@ def display_overview(sites, analysis, checks, tlp = true)
               end
             end
           end
+          # 'downloads' is collected by the crawler rather than via the
+          # standard checks. We only care whether any were found, so it is
+          # treated as a pass/fail column (no downloads -> flagged red).
+          _th! 'Downloads', data_sort: 'string'
         end
       end
       sort_order = {
@@ -205,6 +209,17 @@ def display_overview(sites, analysis, checks, tlp = true)
             checks.each_key do |c|
               cls = SiteStandards.label(analysis, links, c, n)
               _td '', class: cls, data_sort_value: sort_order[cls]
+            end
+            downloads = links['downloads'] || {}
+            if downloads.empty?
+              # No downloads discovered: flag red like other failing cells
+              cls = SiteStandards::SITE_FAIL
+              _td '', class: cls, data_sort_value: sort_order[cls]
+            else
+              cls = SiteStandards::SITE_PASS
+              # Expose the discovered download URLs in a hover tooltip
+              _td '', class: cls, data_sort_value: sort_order[cls],
+                  title: downloads.keys.join("\n")
             end
           end
         end

--- a/lib/whimsy/sitewebsite.rb
+++ b/lib/whimsy/sitewebsite.rb
@@ -232,10 +232,10 @@ def display_overview(sites, analysis, checks, tlp = true)
               cls = SiteStandards::SITE_FAIL
               _td '', class: cls, data_sort_value: sort_order[cls]
             else
-              # Not expected to publish downloads: warn (amber), not a failure
+              # Not expected to publish downloads: warn (amber), not a
+              # failure. See the amber data key above the table.
               cls = SiteStandards::SITE_WARN
-              _td '', class: cls, data_sort_value: sort_order[cls],
-                  title: 'Not expected to publish downloads'
+              _td '', class: cls, data_sort_value: sort_order[cls]
             end
           end
         end


### PR DESCRIPTION
The crawler already collects a 'downloads' map for each site, but it was never surfaced in the all-projects/all-podlings overview table.

Add a 'Downloads' column that flags whether any download links were found: sites with none are marked red (SITE_FAIL) like other failing checks, and sites with downloads are marked green (SITE_PASS) with the discovered URLs available in a hover tooltip. The column uses the same sort_order values as the existing check columns so it sorts pass/fail alongside them.

This is display-only; no changes to the crawler or SiteStandards.